### PR TITLE
Add command for sending message-type pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # companion-module-qsys-remote-control
 See HELP.md and LICENSE
 
-Reference available here: https://q-syshelp.qsc.com/Content/External_Control/Q-Sys_Remote_Control/QRC.htm
+Reference available here: https://q-syshelp.qsc.com/content/External_Control_APIs/QRC/QRC_Overview.htm
 
 **V0.0.1** 
 * Initial module

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Reference available here: https://q-syshelp.qsc.com/Content/External_Control/Q-S
 
 **V2.1.0**
 * Add Snapshot.Load and Snapshot.Save methods
+
+**V2.2.0**
+* Add PA.PageSubmit command for message type pages only

--- a/index.js
+++ b/index.js
@@ -1093,6 +1093,51 @@ class QsysRemoteControl extends InstanceBase {
 						Name: evt.options.name,
 						Bank: evt.options.bank
 				})
+			},
+			page_submit_message: {
+				name: 'PA.PageSubmit - Message',
+				options: [
+					{
+						type: 'textinput',
+						id: 'zones',
+						label: 'Zone Number(s):',
+						tooltip: 'Comma-seperated for multiple zones',
+						regex: "\d+(?:,\d+)*",
+						required: true,
+						default: '',
+					},
+					{
+						type: 'number',
+						id: 'priority',
+						label: 'Priority:',
+						tooltip: "1 is highest",
+						min: 1,
+						required: true,
+						default: '',
+					},
+					{
+						type: 'textinput',
+						id: 'preamble',
+						label: 'Preamble:',
+						tooltip: 'File name of the preamble',
+						default: '',
+					},
+					{
+						type: 'textinput',
+						id: 'message',
+						label: 'Message:',
+						tooltip: 'File name of the message',
+						default: '',
+					}
+				],
+				callback: evt => this.sendCommand('PA.PageSubmit', {
+						Mode: "message",
+						Zones: evt.options.zones.split(",").map(Number),
+						Priority: evt.options.priority,
+						Preamble: evt.options.preamble,
+						Message: evt.options.message,
+						Start: true
+				})
 			}
 		})
 	}


### PR DESCRIPTION
Implemented the PA.PageSubmit command for sending message-type pages from a PA Router running on a Q-Sys core.

I've only implemented the "message" type page because the other page methods require a live mic rather than a pre-recorded mp3.

I also updated the URL to the API docs in the readme because the old one was 404ing.